### PR TITLE
Downgrade Quarkus as the 1.0 version does not respect mainClass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <groupId>biz.karms.quarkus.json</groupId>
@@ -9,11 +8,9 @@
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>2.22.0</surefire-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <quarkus.version>1.0.0.CR1</quarkus.version>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <quarkus.version>0.22.0</quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     <dependencyManagement>
@@ -39,7 +36,6 @@
         </dependency>
     </dependencies>
     <build>
-        <finalName>qjf</finalName>
         <plugins>
             <plugin>
                 <groupId>io.quarkus</groupId>
@@ -52,13 +48,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <mainClass>biz.karms.quarkus.json.formatter.Main</mainClass>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler-plugin.version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -82,6 +71,37 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${quarkus.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <mainClass>biz.karms.quarkus.json.formatter.Main</mainClass>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${quarkus.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <enableHttpUrlHandler>false</enableHttpUrlHandler>
+                                    <finalName>qjf</finalName>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>${surefire-plugin.version}</version>
                         <executions>
@@ -92,9 +112,7 @@
                                 </goals>
                                 <configuration>
                                     <systemProperties>
-                                        <native.image.path>
-                                            ${project.build.directory}/${project.build.finalName}-runner
-                                        </native.image.path>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                                     </systemProperties>
                                 </configuration>
                             </execution>
@@ -102,10 +120,6 @@
                     </plugin>
                 </plugins>
             </build>
-            <properties>
-                <quarkus.package.type>native</quarkus.package.type>
-                <quarkus.native.enable-http-url-handler>false</quarkus.native.enable-http-url-handler>
-            </properties>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Quarkus 0.22.0 still works...

Bad:

```
(base) karm@local:~/workspaceRH/qjf ((v1.0) *%)$ cat ugly.json | ./target/qjf-runner
2019-11-07 15:33:07,322 INFO  [io.quarkus] (main) qjf 1.0.0-SNAPSHOT (running on Quarkus 1.0.0.CR1) started in 0.001s.
2019-11-07 15:33:07,322 INFO  [io.quarkus] (main) Profile prod activated.
2019-11-07 15:33:07,322 INFO  [io.quarkus] (main) Installed features: []
^C2019-11-07 15:33:09,139 INFO  [io.quarkus] (main) qjf stopped in 0.000s
```

Good:

```
(base) karm@local:~/workspaceRH/qjf ((v1.0) %)$ cat ugly.json | ./target/qjf-runner

{
    "configs": {
        "MP30": {
            "supportedServers": [
                "LIBERTY",
<SNIP>
```


@rsvoboda Even if the only difference in the pom is the Quarkus version, it breaks :smiley: 